### PR TITLE
[Feature] Implement Creator NFT contract

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,0 +1,37 @@
+[package]
+name = "ocp"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+license = "Apache 2.0"           # e.g., "MIT", "GPL", "Apache 2.0"
+authors = ["memenow.xyz"]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { local = "../conflicting/version", override = true }
+
+[addresses]
+open-content-protocol = "0x0"
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. You can introduce test-only dependencies here.
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overwriting named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
+

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -1,0 +1,44 @@
+module 0x0::ocp_creator {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+    public struct Creator has key, store {
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+    }
+
+    public entry fun mint_creator(
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Creator {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_creator(
+        creator: &mut Creator,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        creator.url = url;
+        creator.description = description;
+        creator.avatar = avatar;
+    }
+
+}


### PR DESCRIPTION
- Add Creator struct to represent a creator NFT
- Implement mint_creator function to mint a new creator NFT
- Implement update_creator function to update an existing creator NFT
- Use sui::transfer to transfer the minted NFT to the sender's address