### PR TITLE
[Feature] OCP Subscriber Module

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,0 +1,37 @@
+[package]
+name = "ocp"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+license = "Apache 2.0"           # e.g., "MIT", "GPL", "Apache 2.0"
+authors = ["memenow.xyz"]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { local = "../conflicting/version", override = true }
+
+[addresses]
+open-content-protocol = "0x0"
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. You can introduce test-only dependencies here.
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overwriting named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
+

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -1,0 +1,44 @@
+module 0x0::ocp_creator {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+    public struct Creator has key, store {
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+    }
+
+    public entry fun mint_creator(
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Creator {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_creator(
+        creator: &mut Creator,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        creator.url = url;
+        creator.description = description;
+        creator.avatar = avatar;
+    }
+
+}

--- a/sources/ocp_subscriber.move
+++ b/sources/ocp_subscriber.move
@@ -1,0 +1,105 @@
+module 0x0::ocp_subscriber {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+
+    public struct Subscriber has key, store{
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+        creator: address,
+    }
+
+    public struct Post has key, store {
+        id: UID,
+        creator_id: ID,
+        url: String,
+        description: String,
+    }
+    
+    public struct PostKey has key, store{
+        id: UID,
+        post_id: ID,
+    }
+
+    public entry fun mint_post(
+        creator: &0x0::ocp_creator::Creator,
+        url: String,
+        description: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Post {
+            id: object::new(ctx),
+            creator_id: object::id(creator),
+            url,
+            description,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+    public entry fun update_post(
+        post: &mut Post,
+        url: String,
+        description: String,
+        _: &TxContext
+    ) {
+        post.url = url;
+        post.description = description;
+    }
+
+    public entry fun mint_post_key(
+        post: &Post,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let key = PostKey {
+            id: object::new(ctx),
+            post_id: object::id(post),
+        };
+        transfer::transfer(key, sender);
+    }
+
+    public entry fun has_access(
+        post: &Post,
+        key: &PostKey,
+    ):bool {
+        object::id(post) == key.post_id
+    }
+
+    public entry fun mint_subscriber(
+        creator: address,
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        
+        let nft = Subscriber {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+            creator,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_subscriber(
+        subscriber: &mut Subscriber,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        subscriber.url = url;
+        subscriber.description = description;
+        subscriber.avatar = avatar;
+    }
+}


### PR DESCRIPTION
## Description
This pull request introduces the `ocp_subscriber` module, which provides functionality for managing subscribers and their access to posts created by creators in the OCP (Open Content Platform) ecosystem.

## Features
- `Subscriber` struct: Represents a subscriber with their name, URL, description, avatar, and the creator they are subscribed to.
- `Post` struct: Represents a post created by a creator, containing the post's ID, creator ID, URL, and description.
- `PostKey` struct: Represents an access key that grants a subscriber access to a specific post.
- `mint_post` function: Allows creators to mint new posts by providing the post's URL and description.
- `update_post` function: Allows updating the URL and description of an existing post.
- `mint_post_key` function: Mints a new access key for a specific post, which can be transferred to subscribers.
- `has_access` function: Checks if a subscriber has access to a specific post using their access key.
- `mint_subscriber` function: Mints a new subscriber by providing their name, URL, description, avatar, and the creator they are subscribing to.
- `update_subscriber` function: Allows updating the URL, description, and avatar of an existing subscriber.

