### PR TITLE
[Feature] OCP Member Module

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,0 +1,37 @@
+[package]
+name = "ocp"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+license = "Apache 2.0"           # e.g., "MIT", "GPL", "Apache 2.0"
+authors = ["memenow.xyz"]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { local = "../conflicting/version", override = true }
+
+[addresses]
+open-content-protocol = "0x0"
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. You can introduce test-only dependencies here.
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overwriting named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
+

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -4,6 +4,8 @@ module 0x0::ocp_creator {
     use sui::transfer;
     use std::string::String;
 
+    /// The `Creator` struct represents a creator in the OCP.
+    /// It contains information about the creator, such as their name, URL, description, and avatar.
     public struct Creator has key, store {
         id: UID,
         name: address,
@@ -12,6 +14,14 @@ module 0x0::ocp_creator {
         avatar: String,
     }
 
+    /// Mints a new creator and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `url` - The URL of the creator.
+    /// * `description` - The description of the creator.
+    /// * `avatar` - The avatar of the creator.
+    /// * `ctx` - The transaction context.
     public entry fun mint_creator(
         url: String,
         description: String,
@@ -28,7 +38,16 @@ module 0x0::ocp_creator {
         };
         transfer::transfer(nft, sender);
     }
-    
+
+    /// Updates the URL, description, and avatar of an existing creator.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A mutable reference to the `Creator` object to be updated.
+    /// * `url` - The new URL of the creator.
+    /// * `description` - The new description of the creator.
+    /// * `avatar` - The new avatar of the creator.
+    /// * `_` - The transaction context (unused).    
     public entry fun update_creator(
         creator: &mut Creator,
         url: String,

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -1,0 +1,44 @@
+module 0x0::ocp_creator {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+    public struct Creator has key, store {
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+    }
+
+    public entry fun mint_creator(
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Creator {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_creator(
+        creator: &mut Creator,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        creator.url = url;
+        creator.description = description;
+        creator.avatar = avatar;
+    }
+
+}

--- a/sources/ocp_member.move
+++ b/sources/ocp_member.move
@@ -1,0 +1,81 @@
+module 0x0::ocp_member {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+    /// The `Member` struct represents a member in the OCP.
+    /// It contains information about the member, such as their name, URL, description, avatar, and creator.
+    public struct Member has key, store{
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+        creator: address,
+    }
+
+    /// The `Paid` struct represents a paid membership in the OCP.
+    /// It contains information about the paid membership, such as the member's address, creator ID, URL, and description.
+    public struct Paid has key, store{
+        id: UID,
+        member: address,
+        creator: ID,
+        url: String,
+        description: String,
+    }
+
+    /// Mints a new member and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - The address of the creator associated with the member.
+    /// * `url` - The URL of the member.
+    /// * `description` - The description of the member.
+    /// * `avatar` - The avatar of the member.
+    /// * `ctx` - The transaction context.
+    public entry fun mint_member(
+        creator: address,
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);        
+        let nft = Member {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+            creator,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+    /// Mints a new paid membership and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A reference to the `Creator` object associated with the paid membership.
+    /// * `url` - The URL of the paid membership.
+    /// * `description` - The description of the paid membership.
+    /// * `ctx` - The transaction context.
+    public entry fun mint_paid(
+        creator: &0x0::ocp_creator::Creator,
+        url: String,
+        description: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);        
+        let nft = Paid {
+            id: object::new(ctx),
+            member: sender,
+            creator: object::id(creator),
+            url,
+            description,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+}

--- a/sources/ocp_subscriber.move
+++ b/sources/ocp_subscriber.move
@@ -4,7 +4,8 @@ module 0x0::ocp_subscriber {
     use sui::transfer;
     use std::string::String;
 
-
+    /// The `Subscriber` struct represents a subscriber in the OCP.
+    /// It contains information about the subscriber, such as their name, URL, description, avatar, and creator.
     public struct Subscriber has key, store{
         id: UID,
         name: address,
@@ -14,18 +15,30 @@ module 0x0::ocp_subscriber {
         creator: address,
     }
 
+    /// The `Post` struct represents a post created by a creator in the OCP.
+    /// It contains information about the post, such as its ID, creator ID, URL, and description.
     public struct Post has key, store {
         id: UID,
-        creator_id: ID,
+        creator: ID,
         url: String,
         description: String,
     }
     
+    /// The `PostKey` struct represents a key that grants access to a specific post.
+    /// It contains the ID of the key and the ID of the associated post.    
     public struct PostKey has key, store{
         id: UID,
         post_id: ID,
     }
 
+    /// Mints a new post and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A reference to the `Creator` object associated with the post.
+    /// * `url` - The URL of the post.
+    /// * `description` - The description of the post.
+    /// * `ctx` - The transaction context.
     public entry fun mint_post(
         creator: &0x0::ocp_creator::Creator,
         url: String,
@@ -35,13 +48,21 @@ module 0x0::ocp_subscriber {
         let sender = tx_context::sender(ctx);
         let nft = Post {
             id: object::new(ctx),
-            creator_id: object::id(creator),
+            creator: object::id(creator),
             url,
             description,
         };
         transfer::transfer(nft, sender);
     }
 
+    /// Updates the URL and description of an existing post.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A mutable reference to the `Post` object to be updated.
+    /// * `url` - The new URL of the post.
+    /// * `description` - The new description of the post.
+    /// * `_` - The transaction context (unused).
     public entry fun update_post(
         post: &mut Post,
         url: String,
@@ -52,6 +73,12 @@ module 0x0::ocp_subscriber {
         post.description = description;
     }
 
+    /// Mints a new post key and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object associated with the key.
+    /// * `ctx` - The transaction context.
     public entry fun mint_post_key(
         post: &Post,
         ctx: &mut TxContext
@@ -64,6 +91,16 @@ module 0x0::ocp_subscriber {
         transfer::transfer(key, sender);
     }
 
+    /// Checks if a post key grants access to a specific post.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object.
+    /// * `key` - A reference to the `PostKey` object.
+    /// 
+    /// # Returns
+    /// 
+    /// * `bool` - `true` if the post key grants access to the post, `false` otherwise.
     public entry fun has_access(
         post: &Post,
         key: &PostKey,
@@ -71,6 +108,15 @@ module 0x0::ocp_subscriber {
         object::id(post) == key.post_id
     }
 
+    /// Mints a new subscriber and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - The address of the creator associated with the subscriber.
+    /// * `url` - The URL of the subscriber.
+    /// * `description` - The description of the subscriber.
+    /// * `avatar` - The avatar of the subscriber.
+    /// * `ctx` - The transaction context.
     public entry fun mint_subscriber(
         creator: address,
         url: String,
@@ -78,8 +124,7 @@ module 0x0::ocp_subscriber {
         avatar: String,
         ctx: &mut TxContext
     ) {
-        let sender = tx_context::sender(ctx);
-        
+        let sender = tx_context::sender(ctx);        
         let nft = Subscriber {
             id: object::new(ctx),
             name: sender,
@@ -90,7 +135,16 @@ module 0x0::ocp_subscriber {
         };
         transfer::transfer(nft, sender);
     }
-    
+
+    /// Updates the URL, description, and avatar of an existing subscriber.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `subscriber` - A mutable reference to the `Subscriber` object to be updated.
+    /// * `url` - The new URL of the subscriber.
+    /// * `description` - The new description of the subscriber.
+    /// * `avatar` - The new avatar of the subscriber.
+    /// * `_` - The transaction context (unused).    
     public entry fun update_subscriber(
         subscriber: &mut Subscriber,
         url: String,

--- a/sources/ocp_subscriber.move
+++ b/sources/ocp_subscriber.move
@@ -1,0 +1,105 @@
+module 0x0::ocp_subscriber {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+
+    public struct Subscriber has key, store{
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+        creator: address,
+    }
+
+    public struct Post has key, store {
+        id: UID,
+        creator_id: ID,
+        url: String,
+        description: String,
+    }
+    
+    public struct PostKey has key, store{
+        id: UID,
+        post_id: ID,
+    }
+
+    public entry fun mint_post(
+        creator: &0x0::ocp_creator::Creator,
+        url: String,
+        description: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Post {
+            id: object::new(ctx),
+            creator_id: object::id(creator),
+            url,
+            description,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+    public entry fun update_post(
+        post: &mut Post,
+        url: String,
+        description: String,
+        _: &TxContext
+    ) {
+        post.url = url;
+        post.description = description;
+    }
+
+    public entry fun mint_post_key(
+        post: &Post,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let key = PostKey {
+            id: object::new(ctx),
+            post_id: object::id(post),
+        };
+        transfer::transfer(key, sender);
+    }
+
+    public entry fun has_access(
+        post: &Post,
+        key: &PostKey,
+    ):bool {
+        object::id(post) == key.post_id
+    }
+
+    public entry fun mint_subscriber(
+        creator: address,
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        
+        let nft = Subscriber {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+            creator,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_subscriber(
+        subscriber: &mut Subscriber,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        subscriber.url = url;
+        subscriber.description = description;
+        subscriber.avatar = avatar;
+    }
+}


### PR DESCRIPTION
PR Description:

This pull request introduces the implementation of the OCP (Open Collaboration Platform) member module. The module provides functionality for managing members and paid memberships within the OCP ecosystem.

Key features:
- `Member` struct: Represents a member in the OCP, containing information such as the member's name, URL, description, avatar, and creator.
- `Paid` struct: Represents a paid membership in the OCP, including the member's address, creator ID, URL, and description.
- `mint_member` function: Allows minting a new member and transferring it to the sender.
- `mint_paid` function: Enables minting a new paid membership and transferring it to the sender.