### PR TITLE
[Feature] Implement access control for posts using PostKey

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,0 +1,37 @@
+[package]
+name = "ocp"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+license = "Apache 2.0"           # e.g., "MIT", "GPL", "Apache 2.0"
+authors = ["memenow.xyz"]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { local = "../conflicting/version", override = true }
+
+[addresses]
+open-content-protocol = "0x0"
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. You can introduce test-only dependencies here.
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overwriting named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
+

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -4,7 +4,6 @@ module 0x0::ocp_creator {
     use sui::transfer;
     use std::string::String;
 
-
     /// The `Creator` struct represents a creator in the OCP.
     /// It contains information about the creator, such as their name, URL, description, and avatar.
     public struct Creator has key, store {
@@ -13,8 +12,8 @@ module 0x0::ocp_creator {
         url: String,
         description: String,
         avatar: String,
+        member_prices: vector<u64>,
     }
-
 
     /// Mints a new creator and transfers it to the sender.
     /// 
@@ -28,6 +27,7 @@ module 0x0::ocp_creator {
         url: String,
         description: String,
         avatar: String,
+        member_prices: vector<u64>,
         ctx: &mut TxContext
     ) {
         let sender = tx_context::sender(ctx);
@@ -37,11 +37,11 @@ module 0x0::ocp_creator {
             url,
             description,
             avatar,
+            member_prices,
         };
         transfer::transfer(nft, sender);
     }
-    
-    
+      
     /// Updates the URL, description, and avatar of an existing creator.
     /// 
     /// # Arguments
@@ -61,6 +61,14 @@ module 0x0::ocp_creator {
         creator.url = url;
         creator.description = description;
         creator.avatar = avatar;
+    }
+
+    public fun get_creator_name(creator: &Creator): address {
+        creator.name
+    }
+
+    public fun get_member_prices(creator: &Creator): &vector<u64> {
+        &creator.member_prices
     }
 
 }

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -1,6 +1,7 @@
 module 0x0::ocp_creator {
     use std::string::String;
-
+    use sui::event::emit;
+    
     /// The `Creator` struct represents a creator in the OCP.
     /// It contains information about the creator, such as their name, URL, description, and avatar.
     public struct Creator has key, store {
@@ -10,6 +11,36 @@ module 0x0::ocp_creator {
         description: String,
         avatar: String,
         member_prices: vector<u64>,
+    }
+
+    public struct CreatorUpdatedEvent has copy, drop, store {
+        old_creator_id: ID,
+        new_creator_id: ID,
+    }
+
+    public struct PostCreatedEvent has copy, drop, store {
+        post_id: ID,
+        creator: address,
+        access_level: u8,
+    }
+
+    /// The `Post` struct represents a post created by a creator in the OCP.
+    /// It contains information about the post, such as its ID, creator ID, URL, and description.
+    public struct Post has key, store {
+        id: UID,
+        creator: address,
+        url: String,
+        description: String,
+        access_level: u8,
+    }
+    
+    /// The `PostKey` struct represents a key that grants access to a specific post.
+    /// It contains the ID of the key and the ID of the associated post.    
+    public struct PostKey has key, store{
+        id: UID,
+        post_id: ID,
+        access_level: u8,
+        owner: address,
     }
 
     /// Mints a new creator and transfers it to the sender.
@@ -53,11 +84,91 @@ module 0x0::ocp_creator {
         url: String,
         description: String,
         avatar: String,
-        _: &TxContext
     ) {
+        let old_creator_id = object::id(creator);
         creator.url = url;
         creator.description = description;
         creator.avatar = avatar;
+        let new_creator_id = object::id(creator);
+        let event = CreatorUpdatedEvent {
+            old_creator_id,
+            new_creator_id,
+        };
+        emit(event);
+    }
+
+    /// Mints a new post and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A reference to the `Creator` object associated with the post.
+    /// * `url` - The URL of the post.
+    /// * `description` - The description of the post.
+    /// * `ctx` - The transaction context.
+    public entry fun mint_post(
+        creator: &Creator,
+        url: String,
+        description: String,
+        access_level: u8,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let post = Post {
+            id: object::new(ctx),
+            creator: get_creator_name(creator),
+            url,
+            description,
+            access_level,
+        };
+        let post_id = object::id(&post);
+        transfer::transfer(post, sender);
+        let event = PostCreatedEvent {
+            post_id,
+            creator: sender,
+            access_level,
+        };
+        emit(event);
+    }
+
+    /// Updates the URL and description of an existing post.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A mutable reference to the `Post` object to be updated.
+    /// * `url` - The new URL of the post.
+    /// * `description` - The new description of the post.
+    /// * `_` - The transaction context (unused).
+    public entry fun update_post(
+        post: &mut Post,
+        url: String,
+        description: String,
+        access_level: u8,
+        _: &TxContext
+    ) {
+        post.url = url;
+        post.description = description;
+        post.access_level = access_level;
+    }
+
+    /// Mints a new post key and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object associated with the key.
+    /// * `ctx` - The transaction context.
+    public entry fun mint_post_key(
+        post: &Post,
+        access_level: u8,
+        owner: address,
+        ctx: &mut TxContext
+    ) {
+        let key = PostKey {
+            id: object::new(ctx),
+            post_id: object::id(post),
+            access_level,
+            owner,
+        };
+        transfer::transfer(key, owner);
     }
 
     public fun get_creator_name(creator: &Creator): address {
@@ -66,6 +177,50 @@ module 0x0::ocp_creator {
 
     public fun get_member_prices(creator: &Creator): &vector<u64> {
         &creator.member_prices
+    }
+
+    /// Checks if a user has access to a specific post based on their address and a vector of `PostKey`s.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object.
+    /// * `user` - The address of the user.
+    /// * `keys` - A reference to a vector of `PostKey`s owned by the user.
+    /// 
+    /// # Returns
+    /// 
+    /// * `true` if the user has access to the post, `false` otherwise.
+    public fun has_access(post: &Post, user: address, keys: &vector<PostKey>): bool {
+        let required_access_level = post.access_level;
+        if (required_access_level == 0) {
+            return true
+        };
+        check_keys(post, user, keys, required_access_level)
+    }
+
+    /// Checks if a user has a `PostKey` that grants access to a specific post.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object.
+    /// * `user` - The address of the user.
+    /// * `keys` - A reference to a vector of `PostKey`s owned by the user.
+    /// * `required_access_level` - The access level required to view the post.
+    /// 
+    /// # Returns
+    /// 
+    /// * `true` if the user has a `PostKey` that grants access to the post, `false` otherwise.
+    fun check_keys(post: &Post, user: address, keys: &vector<PostKey>, required_access_level: u8): bool {
+        let len = vector::length(keys);
+        let mut i = 0;
+        while (i < len) {
+            let key = vector::borrow(keys, i);
+            if (key.post_id == object::id(post) && key.owner == user && key.access_level >= required_access_level) {
+                return true
+            };
+            i = i + 1;
+        };
+        false
     }
 
 }

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -1,7 +1,4 @@
 module 0x0::ocp_creator {
-    use sui::tx_context;
-    use sui::object;
-    use sui::transfer;
     use std::string::String;
 
     /// The `Creator` struct represents a creator in the OCP.

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -4,6 +4,8 @@ module 0x0::ocp_creator {
     use sui::transfer;
     use std::string::String;
 
+    /// The `Creator` struct represents a creator in the OCP.
+    /// It contains information about the creator, such as their name, URL, description, and avatar.
     public struct Creator has key, store {
         id: UID,
         name: address,
@@ -12,6 +14,14 @@ module 0x0::ocp_creator {
         avatar: String,
     }
 
+    /// Mints a new creator and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `url` - The URL of the creator.
+    /// * `description` - The description of the creator.
+    /// * `avatar` - The avatar of the creator.
+    /// * `ctx` - The transaction context.
     public entry fun mint_creator(
         url: String,
         description: String,
@@ -28,7 +38,16 @@ module 0x0::ocp_creator {
         };
         transfer::transfer(nft, sender);
     }
-    
+
+    /// Updates the URL, description, and avatar of an existing creator.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A mutable reference to the `Creator` object to be updated.
+    /// * `url` - The new URL of the creator.
+    /// * `description` - The new description of the creator.
+    /// * `avatar` - The new avatar of the creator.
+    /// * `_` - The transaction context (unused).    
     public entry fun update_creator(
         creator: &mut Creator,
         url: String,

--- a/sources/ocp_creator.move
+++ b/sources/ocp_creator.move
@@ -1,0 +1,44 @@
+module 0x0::ocp_creator {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+    public struct Creator has key, store {
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+    }
+
+    public entry fun mint_creator(
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Creator {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_creator(
+        creator: &mut Creator,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        creator.url = url;
+        creator.description = description;
+        creator.avatar = avatar;
+    }
+
+}

--- a/sources/ocp_member.move
+++ b/sources/ocp_member.move
@@ -1,0 +1,81 @@
+module 0x0::ocp_member {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+    /// The `Member` struct represents a member in the OCP.
+    /// It contains information about the member, such as their name, URL, description, avatar, and creator.
+    public struct Member has key, store{
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+        creator: address,
+    }
+
+    /// The `Paid` struct represents a paid membership in the OCP.
+    /// It contains information about the paid membership, such as the member's address, creator ID, URL, and description.
+    public struct Paid has key, store{
+        id: UID,
+        member: address,
+        creator: ID,
+        url: String,
+        description: String,
+    }
+
+    /// Mints a new member and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - The address of the creator associated with the member.
+    /// * `url` - The URL of the member.
+    /// * `description` - The description of the member.
+    /// * `avatar` - The avatar of the member.
+    /// * `ctx` - The transaction context.
+    public entry fun mint_member(
+        creator: address,
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);        
+        let nft = Member {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+            creator,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+    /// Mints a new paid membership and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A reference to the `Creator` object associated with the paid membership.
+    /// * `url` - The URL of the paid membership.
+    /// * `description` - The description of the paid membership.
+    /// * `ctx` - The transaction context.
+    public entry fun mint_paid(
+        creator: &0x0::ocp_creator::Creator,
+        url: String,
+        description: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);        
+        let nft = Paid {
+            id: object::new(ctx),
+            member: sender,
+            creator: object::id(creator),
+            url,
+            description,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+}

--- a/sources/ocp_member.move
+++ b/sources/ocp_member.move
@@ -3,7 +3,7 @@ module 0x0::ocp_member {
     use sui::sui::SUI;
     use sui::clock::{Self, Clock};
     use std::string::String;
-    use 0x0::ocp_creator::Creator;
+    use 0x0::ocp_creator::{Creator, get_creator_name};
   
     /// The `Member` struct represents a member in the OCP.
     /// It contains information about the member, such as the member's address, URL, description, and avatar.
@@ -22,7 +22,7 @@ module 0x0::ocp_member {
     public struct Paid has key, store {
         id: UID,
         member: address,
-        creator: ID,
+        creator: address,
         url: String,
         description: String,
     }
@@ -42,7 +42,7 @@ module 0x0::ocp_member {
         url: String,
         description: String,
         avatar: String,
-        clock: &Clock, // Added Clock parameter
+        clock: &Clock,
         ctx: &mut TxContext
     ) {
         let sender = tx_context::sender(ctx);
@@ -129,19 +129,19 @@ module 0x0::ocp_member {
     /// * `description` - The description of the paid membership.
     /// * `ctx` - The transaction context.
     public entry fun mint_paid(
-        creator: &0x0::ocp_creator::Creator,
+        creator: &Creator,
         url: String,
         description: String,
         ctx: &mut TxContext
     ) {
         let sender = tx_context::sender(ctx);
-        let nft = Paid {
+        let paid = Paid {
             id: object::new(ctx),
             member: sender,
-            creator: object::id(creator),
+            creator: get_creator_name(creator),
             url,
             description,
         };
-        transfer::transfer(nft, sender);
-    }
+        transfer::transfer(paid, sender);
+    }    
 }

--- a/sources/ocp_member.move
+++ b/sources/ocp_member.move
@@ -1,13 +1,9 @@
 module 0x0::ocp_member {
-    use sui::tx_context::{Self, TxContext};
-    use sui::object::{Self, UID};
-    use sui::transfer;
     use sui::coin::{Self, Coin};
     use sui::sui::SUI;
     use sui::clock::{Self, Clock};
     use std::string::String;
     use 0x0::ocp_creator::Creator;
-    use std::vector;  
   
     /// The `Member` struct represents a member in the OCP.
     /// It contains information about the member, such as the member's address, URL, description, and avatar.

--- a/sources/ocp_member.move
+++ b/sources/ocp_member.move
@@ -1,47 +1,57 @@
 module 0x0::ocp_member {
-    use sui::tx_context;
-    use sui::object;
+    use sui::tx_context::{Self, TxContext};
+    use sui::object::{Self, UID};
     use sui::transfer;
+    use sui::coin::{Self, Coin};
+    use sui::sui::SUI;
+    use sui::clock::{Self, Clock};
     use std::string::String;
-
+    use 0x0::ocp_creator::Creator;
+    use std::vector;  
+  
     /// The `Member` struct represents a member in the OCP.
-    /// It contains information about the member, such as their name, URL, description, avatar, and creator.
-    public struct Member has key, store{
+    /// It contains information about the member, such as the member's address, URL, description, and avatar.
+    public struct Member has key, store {
         id: UID,
         name: address,
         url: String,
         description: String,
         avatar: String,
         creator: address,
+        expires_at: u64,
     }
-
+  
     /// The `Paid` struct represents a paid membership in the OCP.
     /// It contains information about the paid membership, such as the member's address, creator ID, URL, and description.
-    public struct Paid has key, store{
+    public struct Paid has key, store {
         id: UID,
         member: address,
         creator: ID,
         url: String,
         description: String,
     }
-
-    /// Mints a new member and transfers it to the sender.
-    /// 
+  
+    /// Mints a new `Member` and transfers it to the sender.
+    ///
     /// # Arguments
-    /// 
-    /// * `creator` - The address of the creator associated with the member.
+    ///
+    /// * `creator` - The address of the creator.
     /// * `url` - The URL of the member.
     /// * `description` - The description of the member.
     /// * `avatar` - The avatar of the member.
+    /// * `clock` - A reference to the `Clock` object.
     /// * `ctx` - The transaction context.
     public entry fun mint_member(
         creator: address,
         url: String,
         description: String,
         avatar: String,
+        clock: &Clock, // Added Clock parameter
         ctx: &mut TxContext
     ) {
-        let sender = tx_context::sender(ctx);        
+        let sender = tx_context::sender(ctx);
+        let now = clock::timestamp_ms(clock);
+        let expires_at = now + 30 * 24 * 60 * 60 * 1000; // Membership validity period of one month (in milliseconds)
         let nft = Member {
             id: object::new(ctx),
             name: sender,
@@ -49,14 +59,75 @@ module 0x0::ocp_member {
             description,
             avatar,
             creator,
+            expires_at,
         };
         transfer::transfer(nft, sender);
     }
-
-    /// Mints a new paid membership and transfers it to the sender.
-    /// 
+  
+    /// Renews the membership of a `Member`.
+    ///
     /// # Arguments
-    /// 
+    ///
+    /// * `member` - A mutable reference to the `Member` object.
+    /// * `creator` - A reference to the `Creator` object.
+    /// * `price_index` - The index of the renewal price in the creator's price list.
+    /// * `payment` - The payment in SUI coins.
+    /// * `clock` - A reference to the `Clock` object.
+    /// * `_ctx` - The transaction context.
+    public entry fun renew_member(
+        member: &mut Member,
+        creator: &Creator,
+        price_index: u64,
+        payment: Coin<SUI>,
+        clock: &Clock,
+        _ctx: &mut TxContext
+    ) {
+        // Get the renewal fee
+        let member_prices = 0x0::ocp_creator::get_member_prices(creator);
+        let renewal_fee = *vector::borrow(member_prices, price_index);
+        assert!(coin::value(&payment) >= renewal_fee, 1);
+        let now = clock::timestamp_ms(clock);
+        let new_expires_at = if (member.expires_at > now) {
+            member.expires_at + 30 * 24 * 60 * 60 * 1000
+        } else {
+            now + 30 * 24 * 60 * 60 * 1000
+        };
+        member.expires_at = new_expires_at;
+        transfer::public_transfer(payment, member.creator);
+    }
+  
+    /// Checks if a `Member` is active.
+    ///
+    /// # Arguments
+    ///
+    /// * `member` - A reference to the `Member` object.
+    /// * `clock` - A reference to the `Clock` object.
+    ///
+    /// # Returns
+    ///
+    /// * `bool` - `true` if the member is active, `false` otherwise.
+    public fun is_member_active(member: &Member, clock: &Clock): bool {
+        let now = clock::timestamp_ms(clock);
+        member.expires_at > now
+    }
+  
+    /// Gets the expiration time of a `Member`.
+    ///
+    /// # Arguments
+    ///
+    /// * `member` - A reference to the `Member` object.
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The expiration timestamp of the member.
+    public fun get_member_expiration(member: &Member): u64 {
+        member.expires_at
+    }
+  
+    /// Mints a new `Paid` membership and transfers it to the sender.
+    ///
+    /// # Arguments
+    ///
     /// * `creator` - A reference to the `Creator` object associated with the paid membership.
     /// * `url` - The URL of the paid membership.
     /// * `description` - The description of the paid membership.
@@ -67,7 +138,7 @@ module 0x0::ocp_member {
         description: String,
         ctx: &mut TxContext
     ) {
-        let sender = tx_context::sender(ctx);        
+        let sender = tx_context::sender(ctx);
         let nft = Paid {
             id: object::new(ctx),
             member: sender,
@@ -77,5 +148,4 @@ module 0x0::ocp_member {
         };
         transfer::transfer(nft, sender);
     }
-
 }

--- a/sources/ocp_subscriber.move
+++ b/sources/ocp_subscriber.move
@@ -4,7 +4,8 @@ module 0x0::ocp_subscriber {
     use sui::transfer;
     use std::string::String;
 
-
+    /// The `Subscriber` struct represents a subscriber in the OCP.
+    /// It contains information about the subscriber, such as their name, URL, description, avatar, and creator.
     public struct Subscriber has key, store{
         id: UID,
         name: address,
@@ -14,18 +15,30 @@ module 0x0::ocp_subscriber {
         creator: address,
     }
 
+    /// The `Post` struct represents a post created by a creator in the OCP.
+    /// It contains information about the post, such as its ID, creator ID, URL, and description.
     public struct Post has key, store {
         id: UID,
-        creator_id: ID,
+        creator: ID,
         url: String,
         description: String,
     }
     
+    /// The `PostKey` struct represents a key that grants access to a specific post.
+    /// It contains the ID of the key and the ID of the associated post.    
     public struct PostKey has key, store{
         id: UID,
         post_id: ID,
     }
 
+    /// Mints a new post and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - A reference to the `Creator` object associated with the post.
+    /// * `url` - The URL of the post.
+    /// * `description` - The description of the post.
+    /// * `ctx` - The transaction context.
     public entry fun mint_post(
         creator: &0x0::ocp_creator::Creator,
         url: String,
@@ -35,13 +48,21 @@ module 0x0::ocp_subscriber {
         let sender = tx_context::sender(ctx);
         let nft = Post {
             id: object::new(ctx),
-            creator_id: object::id(creator),
+            creator: object::id(creator),
             url,
             description,
         };
         transfer::transfer(nft, sender);
     }
 
+    /// Updates the URL and description of an existing post.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A mutable reference to the `Post` object to be updated.
+    /// * `url` - The new URL of the post.
+    /// * `description` - The new description of the post.
+    /// * `_` - The transaction context (unused).
     public entry fun update_post(
         post: &mut Post,
         url: String,
@@ -52,6 +73,12 @@ module 0x0::ocp_subscriber {
         post.description = description;
     }
 
+    /// Mints a new post key and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object associated with the key.
+    /// * `ctx` - The transaction context.
     public entry fun mint_post_key(
         post: &Post,
         ctx: &mut TxContext
@@ -64,6 +91,16 @@ module 0x0::ocp_subscriber {
         transfer::transfer(key, sender);
     }
 
+    /// Checks if a post key grants access to a specific post.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `post` - A reference to the `Post` object.
+    /// * `key` - A reference to the `PostKey` object.
+    /// 
+    /// # Returns
+    /// 
+    /// * `bool` - `true` if the post key grants access to the post, `false` otherwise.
     public entry fun has_access(
         post: &Post,
         key: &PostKey,
@@ -71,6 +108,15 @@ module 0x0::ocp_subscriber {
         object::id(post) == key.post_id
     }
 
+    /// Mints a new subscriber and transfers it to the sender.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `creator` - The address of the creator associated with the subscriber.
+    /// * `url` - The URL of the subscriber.
+    /// * `description` - The description of the subscriber.
+    /// * `avatar` - The avatar of the subscriber.
+    /// * `ctx` - The transaction context.
     public entry fun mint_subscriber(
         creator: address,
         url: String,
@@ -78,8 +124,7 @@ module 0x0::ocp_subscriber {
         avatar: String,
         ctx: &mut TxContext
     ) {
-        let sender = tx_context::sender(ctx);
-        
+        let sender = tx_context::sender(ctx);        
         let nft = Subscriber {
             id: object::new(ctx),
             name: sender,
@@ -90,7 +135,16 @@ module 0x0::ocp_subscriber {
         };
         transfer::transfer(nft, sender);
     }
-    
+
+    /// Updates the URL, description, and avatar of an existing subscriber.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `subscriber` - A mutable reference to the `Subscriber` object to be updated.
+    /// * `url` - The new URL of the subscriber.
+    /// * `description` - The new description of the subscriber.
+    /// * `avatar` - The new avatar of the subscriber.
+    /// * `_` - The transaction context (unused).    
     public entry fun update_subscriber(
         subscriber: &mut Subscriber,
         url: String,

--- a/sources/ocp_subscriber.move
+++ b/sources/ocp_subscriber.move
@@ -1,12 +1,5 @@
 module 0x0::ocp_subscriber {
     use std::string::String;
-    use sui::clock::Clock;
-    use 0x0::ocp_member::Member;
-    use 0x0::ocp_creator::Creator;
-
-    const ACCESS_PUBLIC: u8 = 0;
-    const ACCESS_MEMBERS_ONLY: u8 = 1;
-    const ACCESS_PRIVATE: u8 = 2;
 
     /// The `Subscriber` struct represents a subscriber in the OCP.
     /// It contains information about the subscriber, such as their name, URL, description, avatar, and creator.
@@ -17,121 +10,6 @@ module 0x0::ocp_subscriber {
         description: String,
         avatar: String,
         creator: address,
-    }
-
-    /// The `Post` struct represents a post created by a creator in the OCP.
-    /// It contains information about the post, such as its ID, creator ID, URL, and description.
-    public struct Post has key, store {
-        id: UID,
-        creator: ID,
-        url: String,
-        description: String,
-    }
-    
-    /// The `PostKey` struct represents a key that grants access to a specific post.
-    /// It contains the ID of the key and the ID of the associated post.    
-    public struct PostKey has key, store{
-        id: UID,
-        post_id: ID,
-        access_level: u8,
-    }
-
-    /// Mints a new post and transfers it to the sender.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `creator` - A reference to the `Creator` object associated with the post.
-    /// * `url` - The URL of the post.
-    /// * `description` - The description of the post.
-    /// * `ctx` - The transaction context.
-    public entry fun mint_post(
-        creator: &Creator,
-        url: String,
-        description: String,
-        ctx: &mut TxContext
-    ) {
-        let sender = tx_context::sender(ctx);
-        let nft = Post {
-            id: object::new(ctx),
-            creator: object::id(creator),
-            url,
-            description,
-        };
-        transfer::transfer(nft, sender);
-    }
-
-    /// Updates the URL and description of an existing post.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `post` - A mutable reference to the `Post` object to be updated.
-    /// * `url` - The new URL of the post.
-    /// * `description` - The new description of the post.
-    /// * `_` - The transaction context (unused).
-    public entry fun update_post(
-        post: &mut Post,
-        url: String,
-        description: String,
-        _: &TxContext
-    ) {
-        post.url = url;
-        post.description = description;
-    }
-
-    /// Mints a new post key and transfers it to the sender.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `post` - A reference to the `Post` object associated with the key.
-    /// * `ctx` - The transaction context.
-    public entry fun mint_post_key(
-        post: &Post,
-        access_level: u8,
-        ctx: &mut TxContext
-    ) {
-        let sender = tx_context::sender(ctx);
-        let key = PostKey {
-            id: object::new(ctx),
-            post_id: object::id(post),
-            access_level,
-        };
-        transfer::transfer(key, sender);
-    }
-
-    /// Checks if a post key grants access to a specific post.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `post` - A reference to the `Post` object.
-    /// * `key` - A reference to the `PostKey` object.
-    /// 
-    /// # Returns
-    /// 
-    /// * `bool` - `true` if the post key grants access to the post, `false` otherwise.
-    public entry fun has_access(
-        post: &Post,
-        member: &Member,
-        key: &PostKey,
-        clock: &Clock
-    ): bool {
-        object::id(post) == key.post_id && can_access_post(post, member, key, clock)
-    }
-
-    public fun can_access_post(
-        post: &Post,
-        member: &Member,
-        key: &PostKey,
-        clock: &Clock
-    ): bool {
-        if (key.access_level == ACCESS_PUBLIC) {
-            true
-        } else if (key.access_level == ACCESS_MEMBERS_ONLY) {
-            0x0::ocp_member::is_member_active(member, clock)
-        } else if (key.access_level == ACCESS_PRIVATE) {
-            post.creator == object::id(member)
-        } else {
-            false
-        }
     }
 
     /// Mints a new subscriber and transfers it to the sender.
@@ -151,7 +29,7 @@ module 0x0::ocp_subscriber {
         ctx: &mut TxContext
     ) {
         let sender = tx_context::sender(ctx);
-        let nft = Subscriber {
+        let subscriber = Subscriber {
             id: object::new(ctx),
             name: sender,
             url,
@@ -159,7 +37,7 @@ module 0x0::ocp_subscriber {
             avatar,
             creator,
         };
-        transfer::transfer(nft, sender);
+        transfer::transfer(subscriber, sender);
     }
 
     /// Updates the URL, description, and avatar of an existing subscriber.

--- a/sources/ocp_subscriber.move
+++ b/sources/ocp_subscriber.move
@@ -1,0 +1,105 @@
+module 0x0::ocp_subscriber {
+    use sui::tx_context;
+    use sui::object;
+    use sui::transfer;
+    use std::string::String;
+
+
+    public struct Subscriber has key, store{
+        id: UID,
+        name: address,
+        url: String,
+        description: String,
+        avatar: String,
+        creator: address,
+    }
+
+    public struct Post has key, store {
+        id: UID,
+        creator_id: ID,
+        url: String,
+        description: String,
+    }
+    
+    public struct PostKey has key, store{
+        id: UID,
+        post_id: ID,
+    }
+
+    public entry fun mint_post(
+        creator: &0x0::ocp_creator::Creator,
+        url: String,
+        description: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let nft = Post {
+            id: object::new(ctx),
+            creator_id: object::id(creator),
+            url,
+            description,
+        };
+        transfer::transfer(nft, sender);
+    }
+
+    public entry fun update_post(
+        post: &mut Post,
+        url: String,
+        description: String,
+        _: &TxContext
+    ) {
+        post.url = url;
+        post.description = description;
+    }
+
+    public entry fun mint_post_key(
+        post: &Post,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        let key = PostKey {
+            id: object::new(ctx),
+            post_id: object::id(post),
+        };
+        transfer::transfer(key, sender);
+    }
+
+    public entry fun has_access(
+        post: &Post,
+        key: &PostKey,
+    ):bool {
+        object::id(post) == key.post_id
+    }
+
+    public entry fun mint_subscriber(
+        creator: address,
+        url: String,
+        description: String,
+        avatar: String,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        
+        let nft = Subscriber {
+            id: object::new(ctx),
+            name: sender,
+            url,
+            description,
+            avatar,
+            creator,
+        };
+        transfer::transfer(nft, sender);
+    }
+    
+    public entry fun update_subscriber(
+        subscriber: &mut Subscriber,
+        url: String,
+        description: String,
+        avatar: String,
+        _: &TxContext
+    ) {
+        subscriber.url = url;
+        subscriber.description = description;
+        subscriber.avatar = avatar;
+    }
+}


### PR DESCRIPTION
- Add `has_access` function to check if a user has access to a post based on their address and `PostKey`s
- Implement `check_keys` function to iterate through a vector of `PostKey`s and check if any key grants access to the post
- Update `PostKey` struct to include `owner` field to store the address of the key owner
- Modify `mint_post_key` function to accept `owner` parameter and set it in the minted `PostKey`